### PR TITLE
Add error handling to deployment workflow

### DIFF
--- a/.github/workflows/oracle-deploy.yml
+++ b/.github/workflows/oracle-deploy.yml
@@ -23,10 +23,21 @@ jobs:
           username: ubuntu
           key: ${{ secrets.ORACLE_SSH_KEY }}
           script: |
+            set -e  # Exit immediately if any command fails
+
+            echo "📦 Pulling latest code from GitHub..."
             cd /opt/patriot-center
             git pull origin main
+
+            echo "📚 Installing dependencies..."
             source venv/bin/activate
             pip install -r requirements.txt
+
+            echo "🔄 Restarting backend service..."
             sudo systemctl restart patriot-center
+
+            echo "✅ Verifying service is running..."
+            sudo systemctl is-active --quiet patriot-center || exit 1
             sudo systemctl status patriot-center --no-pager
+
             echo "✅ Deployment complete!"


### PR DESCRIPTION
- Add 'set -e' to exit on first failure
- Add service health check after restart
- Add status messages for each deployment step
- Ensure action fails if any critical step fails

This prevents false-positive 'success' when deployment actually fails.