### PR TITLE
fixed starters_loader for live playoff data and fixed caching when testing

### DIFF
--- a/patriot_center_backend/tests/utils/test_cache_utils.py
+++ b/patriot_center_backend/tests/utils/test_cache_utils.py
@@ -100,6 +100,7 @@ class TestLoadCache:
         assert result["2023"] == {}
 
 
+@pytest.mark.usefixtures("use_real_save_cache")
 class TestSaveCache:
     """Test save_cache function."""
 

--- a/patriot_center_backend/utils/ffWAR_loader.py
+++ b/patriot_center_backend/utils/ffWAR_loader.py
@@ -271,6 +271,3 @@ def _calculate_ffWAR_position(scores, season, week, position):
             }
     
     return ffWAR_position
-
-
-load_or_update_ffWAR_cache()

--- a/patriot_center_backend/utils/replacement_score_loader.py
+++ b/patriot_center_backend/utils/replacement_score_loader.py
@@ -333,6 +333,3 @@ def _get_three_yr_avg(season, week, cache):
 
     # Return the updated current week's scores with three-year averages added
     return current_week_scores
-
-# Warm the cache on import so downstream consumers can immediately read from disk/in-memory.
-load_or_update_replacement_score_cache()


### PR DESCRIPTION
- fixed the starters_loader to not assume were looking at old data but instead look at playoff placement if in the last week every time its called 
- also added tests and patched tests that were accidentally loading and saving real cache files